### PR TITLE
correct the pixel to EMU multiplier

### DIFF
--- a/lib/gendocx.js
+++ b/lib/gendocx.js
@@ -237,9 +237,12 @@ function makeDocx ( genobj, new_type, options, gen_private, type_info ) {
 							outString += '<w:rPr>' + rPrData + '</w:rPr>';
 						} // Endif.
 
+						//914400L / 96DPI
+						var pixelToEmu = 9525;
+
 						outString += '<w:drawing>';
 						outString += '<wp:inline distT="0" distB="0" distL="0" distR="0">';
-						outString += '<wp:extent cx="' + (objs_list[i].data[j].options.cx * 10000) + '" cy="' + (objs_list[i].data[j].options.cy * 10000) + '"/>';
+						outString += '<wp:extent cx="' + (objs_list[i].data[j].options.cx * pixelToEmu) + '" cy="' + (objs_list[i].data[j].options.cy * pixelToEmu) + '"/>';
 						outString += '<wp:effectExtent l="19050" t="0" r="9525" b="0"/>';
 						outString += '<wp:docPr id="' + (objs_list[i].data[j].image_id + 1) + '" name="Picture ' + objs_list[i].data[j].image_id + '" descr="Picture ' + objs_list[i].data[j].image_id + '"/>';
 						outString += '<wp:cNvGraphicFramePr>';
@@ -261,7 +264,7 @@ function makeDocx ( genobj, new_type, options, gen_private, type_info ) {
 						outString += '<pic:spPr>';
 						outString += '<a:xfrm>';
 						outString += '<a:off x="0" y="0"/>';
-						outString += '<a:ext cx="' + objs_list[i].data[j].options.cx + '" cy="' + objs_list[i].data[j].options.cy + '"/>';
+						outString += '<a:ext cx="' + (objs_list[i].data[j].options.cx * pixelToEmu) + '" cy="' + (objs_list[i].data[j].options.cy * pixelToEmu) + '"/>';
 						outString += '</a:xfrm>';
 						outString += '<a:prstGeom prst="rect">';
 						outString += '<a:avLst/>';

--- a/lib/genpptx.js
+++ b/lib/genpptx.js
@@ -653,19 +653,19 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 			// Box margins(padding):
 			// BMK_TODO: I should pass a better value as the auto_val parameter of parseSmartNumber().
 			if ( objOptions.bodyProp.bIns ) {
-				bodyProperties += ' bIns="' + parseSmartNumber ( objOptions.bodyProp.bIns, 6858000, 369332, 6858000, 10000 ) + '"';
+				bodyProperties += ' bIns="' + parseSmartNumber ( objOptions.bodyProp.bIns, 6858000, 369332, 6858000, 9525 ) + '"';
 			} // Endif.
 
 			if ( objOptions.bodyProp.lIns ) {
-				bodyProperties += ' lIns="' + parseSmartNumber ( objOptions.bodyProp.lIns, pptWidth, 2819400, pptWidth, 10000 ) + '"';
+				bodyProperties += ' lIns="' + parseSmartNumber ( objOptions.bodyProp.lIns, pptWidth, 2819400, pptWidth, 9525 ) + '"';
 			} // Endif.
 
 			if ( objOptions.bodyProp.rIns ) {
-				bodyProperties += ' rIns="' + parseSmartNumber ( objOptions.bodyProp.rIns, pptWidth, 2819400, pptWidth, 10000 ) + '"';
+				bodyProperties += ' rIns="' + parseSmartNumber ( objOptions.bodyProp.rIns, pptWidth, 2819400, pptWidth, 9525 ) + '"';
 			} // Endif.
 
 			if ( objOptions.bodyProp.tIns ) {
-				bodyProperties += ' tIns="' + parseSmartNumber ( objOptions.bodyProp.tIns, 6858000, 369332, 6858000, 10000 ) + '"';
+				bodyProperties += ' tIns="' + parseSmartNumber ( objOptions.bodyProp.tIns, 6858000, 369332, 6858000, 9525 ) + '"';
 			} // Endif.
 
 			bodyProperties += ' rtlCol="0">';
@@ -726,7 +726,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 			if ( objs_list[i].options ) {
 				if ( typeof objs_list[i].options.cx != 'undefined' ) {
 					if ( objs_list[i].options.cx ) {
-						cx = parseSmartNumber ( objs_list[i].options.cx, pptWidth, 2819400, pptWidth, 10000 );
+						cx = parseSmartNumber ( objs_list[i].options.cx, pptWidth, 2819400, pptWidth, 9525 );
 					} else {
 						cx = 1;
 					} // Endif.
@@ -734,7 +734,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 
 				if ( typeof objs_list[i].options.cy != 'undefined' ) {
 					if ( objs_list[i].options.cy ) {
-						cy = parseSmartNumber ( objs_list[i].options.cy, 6858000, 369332, 6858000, 10000 );
+						cy = parseSmartNumber ( objs_list[i].options.cy, 6858000, 369332, 6858000, 9525 );
 
 					} else {
 						cy = 1;
@@ -742,11 +742,11 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 				} // Endif.
 
 				if ( objs_list[i].options.x ) {
-					x = parseSmartNumber ( objs_list[i].options.x, pptWidth, 0, pptWidth - cx, 10000 );
+					x = parseSmartNumber ( objs_list[i].options.x, pptWidth, 0, pptWidth - cx, 9525 );
 				} // Endif.
 
 				if ( objs_list[i].options.y ) {
-					y = parseSmartNumber ( objs_list[i].options.y, 6858000, 0, 6858000 - cy, 10000 );
+					y = parseSmartNumber ( objs_list[i].options.y, 6858000, 0, 6858000 - cy, 9525 );
 				} // Endif.
 
 				if ( objs_list[i].options.shape ) {


### PR DESCRIPTION
Office uses EMU as the unit of measurement inside documents, where the magic number is 914400 EMU per inch. Office also assumes you view at 96 DPI, giving us 9525 as a multiplier instead of 10000.

The issue I'm trying to fix is aliased lines on embedded images and after some testing - and making sure the freshly opened document is displayed at 100% - I think this is a complete fix.

Libreoffice has a bigger problem, it has no anti-aliasing solution on image, MS Office actually has a quite nice resampling solution, but it's still a visible issue.
