### PR TITLE
Ability to make images into hyperlinks

### DIFF
--- a/lib/genpptx.js
+++ b/lib/genpptx.js
@@ -66,7 +66,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 	/// @param[in] shapeName Either the name of the shape or the shape information.
 	/// @return Information about this shape.
 	///
-
+	
 	var pptWidth = 9144000;
 	var pptType = 'screen4x3';
 
@@ -221,7 +221,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 
 			outText += '<a:effectLst/>';
 			// BMK_TODO: (add support for effects)
-
+			
 			outText += '</p:bgPr></p:bg>';
 		} // Endif.
 
@@ -277,7 +277,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 		// curDateTime.getMinutes () 	Returns the minutes (from 0-59)
 		// curDateTime.getMonth () 	Returns the month (from 0-11)
 		// curDateTime.getSeconds () 	Returns the seconds (from 0-59)
-
+	
 		switch ( field_name ) {
 			// presentation slide number:
 			case 'SLIDE_NUM':
@@ -499,7 +499,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 		if ( text_info.breakLine ) {
 			outBreakP += '</a:p><a:p>';
 		} // Endif.
-
+		
 		return outData + '</a:t>' + endTag + outBreakP;
 	}
 
@@ -515,7 +515,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 	/// @param[in] mul_val ???.
 	/// @return ???.
 	///
-	function parseSmartNumber ( in_data_val, max_value, def_value, auto_val, mul_val ) {
+	function parseSmartNumber ( in_data_val, max_value, def_value, auto_val, mul_val ) {	
 		if ( typeof in_data_val == 'undefined' ) {
 			return (typeof def_value == 'number') ? def_value : 0;
 		} // Endif.
@@ -523,11 +523,11 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 		if ( in_data_val == '' ) {
 			in_data_val = 0;
 		} // Endif.
-
+		
 		if ( typeof in_data_val == 'string' && !isNaN ( in_data_val ) ) {
 			in_data_val = parseInt ( in_data_val, 10 );
 		} // Endif.
-
+	
 		var realNum = Math.round ( mul_val ? in_data_val * mul_val : in_data_val );
 
 		if ( typeof in_data_val == 'string' ) {
@@ -556,7 +556,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 
 			return (typeof def_value == 'number') ? def_value : 0;
 		} // Endif.
-
+	
 		if ( typeof in_data_val == 'number' ) {
 			return realNum;
 		} // Endif.
@@ -944,15 +944,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 
 				// Image:
 				case 'image':
-					var parts = [];
-					parts.push('<p:pic><p:nvPicPr><p:cNvPr id="' + (i + 2) + '" name="Object ' + (i + 1) + '"');
-					if (objs_list[i].link_rel_id) {
-						parts.push('><a:hlinkClick r:id="rId' + objs_list[i].link_rel_id + '"/></p:cNvPr>');
-					} else {
-						parts.push('/>');
-					}
-					parts.push('<p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="rId' + objs_list[i].rel_id + '" cstate="print"/><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr><a:xfrm' + locationAttr + '><a:off x="' + x + '" y="' + y + '"/><a:ext cx="' + cx + '" cy="' + cy + '"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic>');
-					outString += parts.join('');
+					outString += '<p:pic><p:nvPicPr><p:cNvPr id="' + (i + 2) + '" name="Object ' + (i + 1) + '"><a:hlinkClick r:id="rId' + objs_list[i].link_rel_id + '"/></p:cNvPr><p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="rId' + objs_list[i].rel_id + '" cstate="print"/><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr><a:xfrm' + locationAttr + '><a:off x="' + x + '" y="' + y + '"/><a:ext cx="' + cx + '" cy="' + cy + '"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic>';
 					break;
 
 				// Paragraph:
@@ -1006,7 +998,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 						if ( objs_list[i].data[j] ) {
 							moreStylesAttr = '';
 							moreStyles = '';
-
+							
 							if ( objs_list[i].data[j].options ) {
 								if ( objs_list[i].data[j].options.align ) {
 									switch ( objs_list[i].data[j].options.align )
@@ -1061,7 +1053,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 					break;
 			} // End of switch.
 		} // End of for loop.
-
+		
 		outString += '</p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr>';
 
 		if ( timingData != '' ) {
@@ -1456,7 +1448,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 						image_rel_id = j + 1;
 					} // Endif.
 				} // Endif.
-
+			
 			} else
 			{
 				image_id = gen_private.type.msoffice.src_files_list.length;
@@ -1567,7 +1559,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 		};
 
 		gen_private.plugs.intAddAnyResourceToParse ( 'ppt\\slides\\slide' + (pageNumber + 1) + '.xml', 'buffer', gen_private.pages[pageNumber], cbMakePptxSlide, false );
-		gen_private.plugs.intAddAnyResourceToParse ( 'ppt\\slides\\_rels\\slide' + (pageNumber + 1) + '.xml.rels', 'buffer', gen_private.pages[pageNumber].rels, gen_private.plugs.type.msoffice.cbMakeRels, false );
+		gen_private.plugs.intAddAnyResourceToParse ( 'ppt\\slides\\_rels\\slide' + (pageNumber + 1) + '.xml.rels', 'buffer', gen_private.pages[pageNumber].rels, gen_private.plugs.type.msoffice.cbMakeRels, false );		
 		return slideObj;
 	};
 

--- a/lib/genpptx.js
+++ b/lib/genpptx.js
@@ -944,7 +944,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 
 				// Image:
 				case 'image':
-					outString += '<p:pic><p:nvPicPr><p:cNvPr id="' + (i + 2) + '" name="Object ' + (i + 1) + '"/><p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="rId' + objs_list[i].rel_id + '" cstate="print"/><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr><a:xfrm' + locationAttr + '><a:off x="' + x + '" y="' + y + '"/><a:ext cx="' + cx + '" cy="' + cy + '"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic>';
+					outString += '<p:pic><p:nvPicPr><p:cNvPr id="' + (i + 2) + '" name="Object ' + (i + 1) + '"><a:hlinkClick r:id="rId' + objs_list[i].link_rel_id + '"/></p:cNvPr><p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="rId' + objs_list[i].rel_id + '" cstate="print"/><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr><a:xfrm' + locationAttr + '><a:off x="' + x + '" y="' + y + '"/><a:ext cx="' + cx + '" cy="' + cy + '"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic>';
 					break;
 
 				// Paragraph:
@@ -1466,6 +1466,20 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 						clear: 'data'
 					}
 				);
+			} // Endif.
+
+			if ((opt || {}).link) {
+				var link_rel_id = gen_private.pages[pageNumber].rels.length + 1;
+
+				gen_private.pages[pageNumber].rels.push (
+					{
+						type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink',
+						target: opt.link,
+						targetMode: 'External'
+					}
+				);
+
+				gen_private.pages[pageNumber].data[objNumber].link_rel_id = link_rel_id;
 			} // Endif.
 
 			gen_private.pages[pageNumber].data[objNumber].image_id = image_id;

--- a/lib/genpptx.js
+++ b/lib/genpptx.js
@@ -66,7 +66,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 	/// @param[in] shapeName Either the name of the shape or the shape information.
 	/// @return Information about this shape.
 	///
-	
+
 	var pptWidth = 9144000;
 	var pptType = 'screen4x3';
 
@@ -221,7 +221,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 
 			outText += '<a:effectLst/>';
 			// BMK_TODO: (add support for effects)
-			
+
 			outText += '</p:bgPr></p:bg>';
 		} // Endif.
 
@@ -277,7 +277,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 		// curDateTime.getMinutes () 	Returns the minutes (from 0-59)
 		// curDateTime.getMonth () 	Returns the month (from 0-11)
 		// curDateTime.getSeconds () 	Returns the seconds (from 0-59)
-	
+
 		switch ( field_name ) {
 			// presentation slide number:
 			case 'SLIDE_NUM':
@@ -499,7 +499,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 		if ( text_info.breakLine ) {
 			outBreakP += '</a:p><a:p>';
 		} // Endif.
-		
+
 		return outData + '</a:t>' + endTag + outBreakP;
 	}
 
@@ -515,7 +515,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 	/// @param[in] mul_val ???.
 	/// @return ???.
 	///
-	function parseSmartNumber ( in_data_val, max_value, def_value, auto_val, mul_val ) {	
+	function parseSmartNumber ( in_data_val, max_value, def_value, auto_val, mul_val ) {
 		if ( typeof in_data_val == 'undefined' ) {
 			return (typeof def_value == 'number') ? def_value : 0;
 		} // Endif.
@@ -523,11 +523,11 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 		if ( in_data_val == '' ) {
 			in_data_val = 0;
 		} // Endif.
-		
+
 		if ( typeof in_data_val == 'string' && !isNaN ( in_data_val ) ) {
 			in_data_val = parseInt ( in_data_val, 10 );
 		} // Endif.
-	
+
 		var realNum = Math.round ( mul_val ? in_data_val * mul_val : in_data_val );
 
 		if ( typeof in_data_val == 'string' ) {
@@ -556,7 +556,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 
 			return (typeof def_value == 'number') ? def_value : 0;
 		} // Endif.
-	
+
 		if ( typeof in_data_val == 'number' ) {
 			return realNum;
 		} // Endif.
@@ -944,7 +944,15 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 
 				// Image:
 				case 'image':
-					outString += '<p:pic><p:nvPicPr><p:cNvPr id="' + (i + 2) + '" name="Object ' + (i + 1) + '"><a:hlinkClick r:id="rId' + objs_list[i].link_rel_id + '"/></p:cNvPr><p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="rId' + objs_list[i].rel_id + '" cstate="print"/><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr><a:xfrm' + locationAttr + '><a:off x="' + x + '" y="' + y + '"/><a:ext cx="' + cx + '" cy="' + cy + '"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic>';
+					var parts = [];
+					parts.push('<p:pic><p:nvPicPr><p:cNvPr id="' + (i + 2) + '" name="Object ' + (i + 1) + '"');
+					if (objs_list[i].link_rel_id) {
+						parts.push('><a:hlinkClick r:id="rId' + objs_list[i].link_rel_id + '"/></p:cNvPr>');
+					} else {
+						parts.push('/>');
+					}
+					parts.push('<p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="rId' + objs_list[i].rel_id + '" cstate="print"/><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr><a:xfrm' + locationAttr + '><a:off x="' + x + '" y="' + y + '"/><a:ext cx="' + cx + '" cy="' + cy + '"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic>');
+					outString += parts.join('');
 					break;
 
 				// Paragraph:
@@ -998,7 +1006,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 						if ( objs_list[i].data[j] ) {
 							moreStylesAttr = '';
 							moreStyles = '';
-							
+
 							if ( objs_list[i].data[j].options ) {
 								if ( objs_list[i].data[j].options.align ) {
 									switch ( objs_list[i].data[j].options.align )
@@ -1053,7 +1061,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 					break;
 			} // End of switch.
 		} // End of for loop.
-		
+
 		outString += '</p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr>';
 
 		if ( timingData != '' ) {
@@ -1448,7 +1456,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 						image_rel_id = j + 1;
 					} // Endif.
 				} // Endif.
-			
+
 			} else
 			{
 				image_id = gen_private.type.msoffice.src_files_list.length;
@@ -1559,7 +1567,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 		};
 
 		gen_private.plugs.intAddAnyResourceToParse ( 'ppt\\slides\\slide' + (pageNumber + 1) + '.xml', 'buffer', gen_private.pages[pageNumber], cbMakePptxSlide, false );
-		gen_private.plugs.intAddAnyResourceToParse ( 'ppt\\slides\\_rels\\slide' + (pageNumber + 1) + '.xml.rels', 'buffer', gen_private.pages[pageNumber].rels, gen_private.plugs.type.msoffice.cbMakeRels, false );		
+		gen_private.plugs.intAddAnyResourceToParse ( 'ppt\\slides\\_rels\\slide' + (pageNumber + 1) + '.xml.rels', 'buffer', gen_private.pages[pageNumber].rels, gen_private.plugs.type.msoffice.cbMakeRels, false );
 		return slideObj;
 	};
 

--- a/lib/genpptx.js
+++ b/lib/genpptx.js
@@ -944,7 +944,15 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 
 				// Image:
 				case 'image':
-					outString += '<p:pic><p:nvPicPr><p:cNvPr id="' + (i + 2) + '" name="Object ' + (i + 1) + '"><a:hlinkClick r:id="rId' + objs_list[i].link_rel_id + '"/></p:cNvPr><p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="rId' + objs_list[i].rel_id + '" cstate="print"/><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr><a:xfrm' + locationAttr + '><a:off x="' + x + '" y="' + y + '"/><a:ext cx="' + cx + '" cy="' + cy + '"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic>';
+					var parts = [];
+					parts.push('<p:pic><p:nvPicPr><p:cNvPr id="' + (i + 2) + '" name="Object ' + (i + 1) + '"');
+					if (objs_list[i].link_rel_id) {
+						parts.push('><a:hlinkClick r:id="rId' + objs_list[i].link_rel_id + '"/></p:cNvPr>');
+					} else {
+						parts.push('/>');
+					}
+					parts.push('<p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="rId' + objs_list[i].rel_id + '" cstate="print"/><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr><a:xfrm' + locationAttr + '><a:off x="' + x + '" y="' + y + '"/><a:ext cx="' + cx + '" cy="' + cy + '"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic>');
+					outString += parts.join('');
 					break;
 
 				// Paragraph:


### PR DESCRIPTION
I have a use case where I need to make an image into a clickable link. It's not immediately clear how to do this in a flexible way (i.e. so it could apply equally well to text elements in a slide), but I have a working patch to allow it for an image. If you have suggestions on how it could be implemented more generally, I will be happy to update the PR.

Usage is simply an option `link` passed to the `addImage` function in its options hash. The value of `link` is the URL that the image should link to, e.g.

`slide.addImage(..., { "link": "http://www.google.com" });`