### PR TITLE
Fix "setWidescreen" causing corrupt PowerPoint files

### DIFF
--- a/lib/genpptx.js
+++ b/lib/genpptx.js
@@ -66,7 +66,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 	/// @param[in] shapeName Either the name of the shape or the shape information.
 	/// @return Information about this shape.
 	///
-	
+
 	var pptWidth = 9144000;
 	var pptType = 'screen4x3';
 
@@ -221,7 +221,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 
 			outText += '<a:effectLst/>';
 			// BMK_TODO: (add support for effects)
-			
+
 			outText += '</p:bgPr></p:bg>';
 		} // Endif.
 
@@ -277,7 +277,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 		// curDateTime.getMinutes () 	Returns the minutes (from 0-59)
 		// curDateTime.getMonth () 	Returns the month (from 0-11)
 		// curDateTime.getSeconds () 	Returns the seconds (from 0-59)
-	
+
 		switch ( field_name ) {
 			// presentation slide number:
 			case 'SLIDE_NUM':
@@ -499,7 +499,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 		if ( text_info.breakLine ) {
 			outBreakP += '</a:p><a:p>';
 		} // Endif.
-		
+
 		return outData + '</a:t>' + endTag + outBreakP;
 	}
 
@@ -515,7 +515,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 	/// @param[in] mul_val ???.
 	/// @return ???.
 	///
-	function parseSmartNumber ( in_data_val, max_value, def_value, auto_val, mul_val ) {	
+	function parseSmartNumber ( in_data_val, max_value, def_value, auto_val, mul_val ) {
 		if ( typeof in_data_val == 'undefined' ) {
 			return (typeof def_value == 'number') ? def_value : 0;
 		} // Endif.
@@ -523,11 +523,11 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 		if ( in_data_val == '' ) {
 			in_data_val = 0;
 		} // Endif.
-		
+
 		if ( typeof in_data_val == 'string' && !isNaN ( in_data_val ) ) {
 			in_data_val = parseInt ( in_data_val, 10 );
 		} // Endif.
-	
+
 		var realNum = Math.round ( mul_val ? in_data_val * mul_val : in_data_val );
 
 		if ( typeof in_data_val == 'string' ) {
@@ -536,7 +536,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 				if ( realMax <= 0 ) return 0;
 
 				var realVal = parseInt ( in_data_val, 10 );
-				return (realMax / 100) * realVal;
+				return Math.round ( (realMax / 100) * realVal );
 			} // Endif.
 
 			if ( in_data_val.indexOf ( '#' ) != -1 ) {
@@ -551,12 +551,12 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 			} // Endif.
 
 			if ( in_data_val == 'c' ) {
-				return realAuto / 2;
+				return Math.round ( realAuto / 2 );
 			} // Endif.
 
 			return (typeof def_value == 'number') ? def_value : 0;
 		} // Endif.
-	
+
 		if ( typeof in_data_val == 'number' ) {
 			return realNum;
 		} // Endif.
@@ -998,7 +998,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 						if ( objs_list[i].data[j] ) {
 							moreStylesAttr = '';
 							moreStyles = '';
-							
+
 							if ( objs_list[i].data[j].options ) {
 								if ( objs_list[i].data[j].options.align ) {
 									switch ( objs_list[i].data[j].options.align )
@@ -1053,7 +1053,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 					break;
 			} // End of switch.
 		} // End of for loop.
-		
+
 		outString += '</p:spTree></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr>';
 
 		if ( timingData != '' ) {
@@ -1448,7 +1448,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 						image_rel_id = j + 1;
 					} // Endif.
 				} // Endif.
-			
+
 			} else
 			{
 				image_id = gen_private.type.msoffice.src_files_list.length;
@@ -1545,7 +1545,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 		};
 
 		gen_private.plugs.intAddAnyResourceToParse ( 'ppt\\slides\\slide' + (pageNumber + 1) + '.xml', 'buffer', gen_private.pages[pageNumber], cbMakePptxSlide, false );
-		gen_private.plugs.intAddAnyResourceToParse ( 'ppt\\slides\\_rels\\slide' + (pageNumber + 1) + '.xml.rels', 'buffer', gen_private.pages[pageNumber].rels, gen_private.plugs.type.msoffice.cbMakeRels, false );		
+		gen_private.plugs.intAddAnyResourceToParse ( 'ppt\\slides\\_rels\\slide' + (pageNumber + 1) + '.xml.rels', 'buffer', gen_private.pages[pageNumber].rels, gen_private.plugs.type.msoffice.cbMakeRels, false );
 		return slideObj;
 	};
 


### PR DESCRIPTION
Using the `setWidescreen` function often created corrupt PowerPoints. This PR fixes the issue by ensuring all slide dimensions are integers.

There is a lot of noise in this commit because I also stripped excess whitespace in the file. The real changes are lines 539 and 554. I'm happy to eliminate the whitespace noise from this commit if you like.