### PR TITLE
Specify text space with "char_spacing": <float>

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Font properties:
 - font_size (in points)
 - bold: true
 - underline: true
+- char_spacing: floating point number (kerning)
 
 Text alignment properties:
 

--- a/lib/genpptx.js
+++ b/lib/genpptx.js
@@ -398,6 +398,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 		out_obj.bold = '';
 		out_obj.underline = '';
 		out_obj.rpr_info = '';
+		out_obj.char_spacing = '';
 
 		if ( typeof text_info == 'object' )
 		{
@@ -411,6 +412,12 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 
 			if ( text_info.font_size ) {
 				out_obj.font_size = ' sz="' + text_info.font_size + '00"';
+			} // Endif.
+
+			if ( text_info.char_spacing ) {
+				out_obj.char_spacing = ' spc="' + (text_info.char_spacing * 100) + '"';
+				// must also disable kerning; otherwise text won't actually expand
+				out_obj.char_spacing += ' kern="0"';
 			} // Endif.
 
 			if ( text_info.color ) {
@@ -452,7 +459,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 	function cMakePptxOutTextCommand ( text_info, text_string, slide_obj, slide_num ) {
 		var area_opt_data = cMakePptxOutTextData ( text_info, slide_obj );
 		var parsedText;
-		var startInfo = '<a:rPr lang="en-US"' + area_opt_data.font_size + area_opt_data.bold + area_opt_data.underline + ' dirty="0" smtClean="0"' + (area_opt_data.rpr_info != '' ? ('>' + area_opt_data.rpr_info) : '/>') + '<a:t>';
+		var startInfo = '<a:rPr lang="en-US"' + area_opt_data.font_size + area_opt_data.bold + area_opt_data.underline + area_opt_data.char_spacing + ' dirty="0" smtClean="0"' + (area_opt_data.rpr_info != '' ? ('>' + area_opt_data.rpr_info) : '/>') + '<a:t>';
 		var endTag = '</a:r>';
 		var outData = '<a:r>' + startInfo;
 


### PR DESCRIPTION
This adds the ability to change text kerning by passing a floating point number to the `addText` function.

For example:
```js
slide.addText("Test", { "char_spacing": 2.5 }); // prints text that looks like "T  e  s  t"
```