### PR TITLE
PPTX fix for latest version of Apple Keynote

### DIFF
--- a/lib/genpptx.js
+++ b/lib/genpptx.js
@@ -1115,6 +1115,32 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 		}
 	);
 
+	// Apple Keynote requires these added *after* all slides.
+	genobj.on('beforeGen', function() {
+		gen_private.type.msoffice.rels_app.push (
+			{
+				type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/presProps',
+				target: 'presProps.xml',
+				clear: 'type'
+			},
+			{
+				type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/viewProps',
+				target: 'viewProps.xml',
+				clear: 'type'
+			},
+			{
+				type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme',
+				target: 'theme/theme1.xml',
+				clear: 'type'
+			},
+			{
+				type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/tableStyles',
+				target: 'tableStyles.xml',
+				clear: 'type'
+			}
+		);
+	});
+
 	gen_private.plugs.intAddAnyResourceToParse ( 'ppt\\_rels\\presentation.xml.rels', 'buffer', gen_private.type.msoffice.rels_app, gen_private.plugs.type.msoffice.cbMakeRels, true );
 
 	// ----- API for PowerPoint documents: -----


### PR DESCRIPTION
Add presProps.xml, viewProps.xml, theme/theme1.xml, and tableStyles.xml relationships to ppt/_rels/presentation.xml.rels after all slides are added. Required for use with latest version of Apple Keynote; Microsoft PowerPoint functions properly with or without.