### PR TITLE
Set cols width in xlsx

### DIFF
--- a/lib/genxlsx.js
+++ b/lib/genxlsx.js
@@ -307,7 +307,13 @@ function makeXlsx ( genobj, new_type, options, gen_private, type_info ) {
 		// outString += '<selection activeCell="A1" sqref="A1"/>';
 		outString += '</sheetViews><sheetFormatPr defaultRowHeight="15"/>';
 
-		// BMK_TODO: <cols><col min="2" max="2" width="19" customWidth="1"/></cols>
+		if ( data.sheet.width ) {
+			outString += '<cols>';
+			for ( var i = 0; i < data.sheet.width.length; i++ ) {
+				outString += "<col min=\"" + (i+1) + "\" max=\"" + (i+1) + "\" width=\"" + data.sheet.width[i] + "\" customWidth=\"1\"/>";
+			}
+			outString += '</cols>';
+		}
 
 		outString += '<sheetData>';
 


### PR DESCRIPTION
It's now possible to set the cols width for a sheet just by setting an ordered array as a sheetObj property named "width". 
For example: "sheet1.width = [20,50,30]" will set the first column of sheet1 to 20, the second to 50 and the third to 30.