### PR TITLE
add support for GIF

### DIFF
--- a/lib/msofficegen.js
+++ b/lib/msofficegen.js
@@ -365,6 +365,11 @@ function makemsdoc ( genobj, new_type, options, gen_private, type_info ) {
 				clear: 'type'
 			},
 			{
+				ext: 'gif',
+				type: 'image/gif',
+				clear: 'type'
+			},
+			{
 				name: '/docProps/app.xml',
 				type: 'application/vnd.openxmlformats-officedocument.extended-properties+xml',
 				clear: 'type'


### PR DESCRIPTION
Now if you add a GIF image, you will get a broken `.docx` file.

It will show the following message:

<img width="541" alt="1" src="https://cloud.githubusercontent.com/assets/1052188/12003845/30272878-ab6b-11e5-9a80-2e73f6448265.png">

And this PR:

- Add `<Default ContentType="image/gif" Extension="gif"/>` in `[Content_Types].xml`.