### PR TITLE
Prevent corrupt Excel sheet

### DIFF
--- a/lib/msexcel-builder.js
+++ b/lib/msexcel-builder.js
@@ -294,7 +294,8 @@
     function Sheet(book, name, cols, rows) {
       var i, j, _i, _j, _ref, _ref1;
       this.book = book;
-      this.name = name;
+      # replace special characters and extras spaces to prevent corrupt document.
+      this.name = name.replace(/[`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/]/gi, '').replace(/\s{2,}/, " ");
       this.cols = cols;
       this.rows = rows;
       this.data = {};


### PR DESCRIPTION
Removing special characters and consecutive spaces in Sheet `name` will prevent document from being corrupt.