### PR TITLE
PPTX Widescreen Centering Fix

### DIFF
--- a/lib/genpptx.js
+++ b/lib/genpptx.js
@@ -770,7 +770,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 			if ( objs_list[i].options ) {
 				if ( typeof objs_list[i].options.cx != 'undefined' ) {
 					if ( objs_list[i].options.cx ) {
-						cx = parseSmartNumber ( objs_list[i].options.cx, 9144000, 2819400, 9144000, 10000 );
+						cx = parseSmartNumber ( objs_list[i].options.cx, pptWidth, 2819400, pptWidth, 10000 );
 
 					} else {
 						cx = 1;
@@ -787,7 +787,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 				} // Endif.
 
 				if ( objs_list[i].options.x ) {
-					x = parseSmartNumber ( objs_list[i].options.x, 9144000, 0, 9144000 - cx, 10000 );
+					x = parseSmartNumber ( objs_list[i].options.x, pptWidth, 0, pptWidth - cx, 10000 );
 				} // Endif.
 
 				if ( objs_list[i].options.y ) {


### PR DESCRIPTION
Uses pptWidth for obj cx and x calculations instead of hard coded number. This picks up the value set for pptWidth when setWidescreen(true).
