### PR TITLE
Provide varying column sizes in Word tables

### DIFF
--- a/lib/docxtable.js
+++ b/lib/docxtable.js
@@ -99,7 +99,7 @@ module.exports = {
   _tblGrid: function(opts) {
     return {
       "w:gridCol": {
-        "@w:w": opts.tableColWidth || "0"
+        "@w:w": opts.tableColWidth || "1"
       }
     };
   },


### PR DESCRIPTION
The cellColWidth option that is copied to the w:w on a w:tcW only works if the w:gridCol is a non-zero value. With w:gridCol set to "1", it is now possible to set table columns to different widths by using the cellColWidth on the columns for the first (generally the header) row, rather than having to set a constant column width in the table options.