### PR TITLE
All inside table borders

### DIFF
--- a/lib/docxtable.js
+++ b/lib/docxtable.js
@@ -82,6 +82,18 @@ module.exports = {
           "@w:sz": "12",
           "@w:space": "0",
           "@w:color": "000000"
+        },
+        "w:insideH": {
+          "@w:val": "single",
+          "@w:sz": "12",
+          "@w:space": "0",
+          "@w:color": "000000"
+        },
+        "w:insideV": {
+          "@w:val": "single",
+          "@w:sz": "12",
+          "@w:space": "0",
+          "@w:color": "000000"
         }
       };
     }
@@ -95,7 +107,7 @@ module.exports = {
     });
   },
 
-  // TODO 
+  // TODO
   _tblGrid: function(opts) {
     return {
       "w:gridCol": {


### PR DESCRIPTION
I've added the inside table borders when the "borders" option is set for a table. In my opinion this is typically what someone is looking for when they turn borders on - the "grid" effect of having every cell inside a border. 

If it would be better to have separate options for the different positions of borders, I'm happy to do that instead.