### PR TITLE
Use explicit options in docx example

### DIFF
--- a/examples/make_docx.js
+++ b/examples/make_docx.js
@@ -4,7 +4,7 @@ var officegen = require('../lib/index.js');
 var fs = require('fs');
 var path = require('path');
 
-var docx = officegen ( 'docx' );
+var docx = officegen ( { type: 'docx', orientation: 'portrait' } );
 
 // Remove this comment in case of debugging Officegen:
 // officegen.setVerboseMode ( true );


### PR DESCRIPTION
The example was passing officegen() a string, 'docx', so it wasn't obvious where to put document-level options. Used the "type" key in a map instead along with an explicit orientation.