### PR TITLE
Add support for stacked column charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ PowerPoint slides can contain charts with embedded data.  To create a chart:
 Where `chartInfo` object is an object that takes the following attributes:
 
  - `data` -  an array of data, see examples below
- - `renderType` -  specifies base chart type, may be one of `"bar", "pie", "group-bar", "column", "line"`
+ - `renderType` -  specifies base chart type, may be one of `"bar", "pie", "group-bar", "column", "stacked-column", "line"`
  - `title` -  chart title (default: none)
  - `valAxisTitle` -  value axis title (default: none)
  - `catAxisTitle` - category axis title (default: none)

--- a/examples/make_pptx_charts.js
+++ b/examples/make_pptx_charts.js
@@ -241,6 +241,52 @@ var chartsData = [
   },
 
   {
+    title: 'eSurvey chart',
+    renderType: 'stacked-column',
+    valAxisNumFmt: '$0',
+    valAxisMaxValue: 24,
+    data: [
+      {
+        name: 'europe',
+        labels: ['Y2003', 'Y2004', 'Y2005'],
+        values: [2.5, 2.6, 2.8],
+        color: 'ff0000'
+      },
+      {
+        name: 'namerica',
+        labels: ['Y2003', 'Y2004', 'Y2005'],
+        values: [2.5, 2.7, 2.9],
+        color: '00ff00'
+      },
+      {
+        name: 'asia',
+        labels: ['Y2003', 'Y2004', 'Y2005'],
+        values: [2.1, 2.2, 2.4],
+        color: '0000ff'
+      },
+      {
+        name: 'lamerica',
+        labels: ['Y2003', 'Y2004', 'Y2005'],
+        values: [0.3, 0.3, 0.3],
+        color: 'ffff00'
+      },
+      {
+        name: 'meast',
+        labels: ['Y2003', 'Y2004', 'Y2005'],
+        values: [0.2, 0.3, 0.3],
+        color: 'ff00ff'
+      },
+      {
+        name: 'africa',
+        labels: ['Y2003', 'Y2004', 'Y2005'],
+        values: [0.1, 0.1, 0.1],
+        color: '00ffff'
+      }
+
+    ]
+  },
+
+  {
     title: 'Sample bar chart',
     renderType: 'bar',
     xmlOptions: {

--- a/lib/charts.js
+++ b/lib/charts.js
@@ -154,6 +154,79 @@ module.exports = {
       }
     };
   },
+  "stacked-column": function (options) {
+    options = options || {};
+    return  {
+      "c:chartSpace": {
+        "@xmlns:c": "http://schemas.openxmlformats.org/drawingml/2006/chart",
+        "@xmlns:a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+        "@xmlns:r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+        "c:lang": { "@val": "en-US" },
+        "c:date1904": { "@val": "1" },
+        "c:chart": {
+          "c:plotArea": {
+            "c:layout": {},
+            "c:barChart": {
+              "c:barDir": { "@val": "col" },
+              "c:grouping": { "@val": "stacked" },
+              "c:overlap": { "@val": options.overlap || "100" },
+              "c:gapWidth": { "@val": options.gapWidth || "25" },
+
+              "#list": [
+                {"c:axId": { "@val": "64451712" }},
+                {"c:axId": { "@val": "64453248" }}
+              ]
+            },
+            "c:catAx": {
+              "c:axId": { "@val": "64451712" },
+              "c:scaling": {
+                "c:orientation": { "@val": options.catAxisReverseOrder ? "maxMin" : "minMax" }
+              },
+              "c:axPos": { "@val": "l" },
+              "c:tickLblPos": { "@val": "nextTo" },
+              "c:crossAx": { "@val": "64453248" },
+              "c:crosses": { "@val": "autoZero" },
+              "c:auto": { "@val": "1" },
+              "c:lblAlgn": { "@val": "ctr" },
+              "c:lblOffset": { "@val": "100" }
+            },
+            "c:valAx": {
+              "c:axId": { "@val": "64453248" },
+              "c:scaling": {
+                "c:orientation": { "@val": "minMax" }
+              },
+              "c:axPos": { "@val": "b" },
+//              "c:majorGridlines": {},
+              "c:numFmt": {
+                "@formatCode": "General",
+                "@sourceLinked": "1"
+              },
+              "c:tickLblPos": { "@val": "nextTo" },
+              "c:crossAx": { "@val": "64451712" },
+              "c:crosses": { "@val": options.valAxisCrossAtMaxCategory ? "max" : "autoZero"},
+              "c:crossBetween": { "@val": "between" }
+            }
+          },
+          "c:legend": {
+            "c:legendPos": { "@val": "r" },
+            "c:layout": {}
+          },
+          "c:plotVisOnly": { "@val": "1" }
+        },
+        "c:txPr": {
+          "a:bodyPr": {},
+          "a:lstStyle": {},
+          "a:p": {
+            "a:pPr": {
+              "a:defRPr": { "@sz": "1800" }
+            },
+            "a:endParaRPr": { "@lang": "en-US" }
+          }
+        },
+        "c:externalData": { "@r:id": "rId1" }
+      }
+    };
+  },
   "group-bar": function (options) {
     options = options || {};
     return {

--- a/test_files/charts-data.js
+++ b/test_files/charts-data.js
@@ -138,6 +138,26 @@ module.exports = [
     ]
   },
   {
+    title: 'eSurvey chart',
+    renderType: 'stacked-column',
+    valAxisNumFmt: '$0',
+    valAxisMaxValue: 24,
+    data: [
+      {
+        name: 'Income',
+        labels: ['2005', '2006', '2007', '2008', '2009'],
+        values: [23.5, 26.2, 30.1, 29.5, 24.6],
+        color: 'ff0000'
+      },
+      {
+        name: 'Expense',
+        labels: ['2005', '2006', '2007', '2008', '2009'],
+        values: [18.1, 22.8, 23.9, 25.1, 25],
+        color: '00ff00'
+      }
+    ]
+  },
+  {
     title: 'Sample bar chart',
     renderType: 'bar',
     xmlOptions: {


### PR DESCRIPTION
Based on the column chart - this PR adds a simple way to generate stacked columns:
![image](https://cloud.githubusercontent.com/assets/1387956/19000286/a6d0ef9a-8739-11e6-92a0-307fcc71e666.png)
