### PR TITLE
Remove temporary resources just before closing

### DIFF
--- a/lib/basicgen.js
+++ b/lib/basicgen.js
@@ -417,14 +417,6 @@ var officegen = function ( options ) {
 						} // Endif.
 
 						archive.append ( resStream, { name: privateData.resources[cur_index].name } );
-						if( privateData.resources[cur_index].removed_after_used )
-						{
-							// delete the temporatory resources after used
-							// @author vtloc
-							// @date 2014Jan10
-							var fileName = privateData.resources[cur_index].data || privateData.resources[cur_index].name;
-							fs.unlinkSync( fileName );
-						} // Endif.
 
 						generateNextResource ( cur_index + 1 );
 
@@ -443,6 +435,19 @@ var officegen = function ( options ) {
 				} // Endif.
 
 			} else {
+				// now we can remove all temporary resources
+				privateData.resources.forEach(function (resource) {
+					if (resource.removed_after_used){
+						var filename = resource.data || resource.name;
+
+						if ( officegenGlobals.settings.verbose ) {
+							console.log("[officegen] Removing resource: ", filename);
+						}
+
+						fs.unlinkSync(filename);
+					}
+				});
+
 				// No more resources to add - close the archive:
 				if ( officegenGlobals.settings.verbose ) {
 					console.log("[officegen] Finalizing archive ...");


### PR DESCRIPTION
There seems to be a race condition where the sample[n].xlsx files are 
removed before the archiver has a chance to append/include them.

This causes the error 'no such file or directory sample[n].xlsx'.

This PR moves the removal of temporary resources to much later in the 
build process - after all the resources have been added.