### PR TITLE
Use EMU (English Metric Unit) to point conversation (12700) for pptx dimensions

### DIFF
--- a/lib/genpptx.js
+++ b/lib/genpptx.js
@@ -79,8 +79,9 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 	 * @return Information about this shape.
 	 */
 
-	var pptWidth = 9144000;
-  var pptHeight = 6858000;
+	var EMUS_PER_PT = 12700;
+	var pptWidth = 720 * EMUS_PER_PT;
+	var pptHeight = 540 * EMUS_PER_PT;
 	var pptType = 'screen4x3';
 
 	function getShapeInfo ( shapeName ) {
@@ -1896,7 +1897,7 @@ function makePptx ( genobj, new_type, options, gen_private, type_info ) {
 	};
 
 	genobj.setWidescreen = function(wide){
-		pptWidth 	= wide ? 12191996 		: pptWidth;
+		pptWidth 	= wide ? (960 * EMUS_PER_PT) : pptWidth;
 		pptType 	= wide ? 'screen16x9' 	: 'screen4x3';
 	}
 


### PR DESCRIPTION
This fixes an issue where a widescreen pptx opened in Keynote shows a width of 959pts instead of 960pts. Additionally, this removes ambiguity about how the values for pptWidth and pptHeight are derived.