### PR TITLE
Add support to grid span option

### DIFF
--- a/lib/docxtable.js
+++ b/lib/docxtable.js
@@ -152,6 +152,9 @@ module.exports = {
             "@w:w": opts.cellColWidth || tblOpts.tableColWidth || "0",
             "@w:type": "dxa"
           },
+          "w:gridSpan": {
+            "@w:val" : opts.gridSpan || "1"
+          },
           "w:vAlign": {
             "@w:val": opts.vAlign || "top"
           },


### PR DESCRIPTION
In example "make_table_cell_span.js" on line 58 opts: {gridSpan: 2} not work without this changes