### PR TITLE
Table properties

### DIFF
--- a/lib/genofficetable.js
+++ b/lib/genofficetable.js
@@ -124,6 +124,8 @@ module.exports = {
                 "@sz": ""+font_size*100,
                 "@dirty": "0",
                 "@smtClean": "0",
+				"@b":options.bold?(options.bold[row_idx]?(options.bold[row_idx][idx]?options.bold[row_idx][idx]:"0"):"0"):"0",
+                "@i":options.italics?(options.italics[row_idx]?(options.italics[row_idx][idx]?options.italics[row_idx][idx]:"0"):"0"):"0",
                 "a:latin": {
                   "@typeface": font_face
                 },


### PR DESCRIPTION
Added cell level properties for making the cell bold or italic by giving the following properties

- bold: it receives the parameters as an array of array(e.g [["0","1","0","1"],["0","0","0","1"],["0","1","0","0"]])the values for the  array can be "1" for bold and "0" normal ,default is set to normal
- italics: it receives the parameters as an array of array(e.g [["0","1","0","1"],["0","0","0","1"],["0","1","0","0"]])the values for the  array can be "1" for italics and "0" normal ,default is set to normal 

Example:
  slide.addTable(rows, {'tabstyle':'{F5AB1C69-6EDB-4FF4-983F-18BD219EF322}',
                                     'bold':[["0","1","1"],["0","1","1"],["0","1","1"],["0","1","1"]],
                                     'italics':[["0","1","1"],["1","1","0"],["1","1","1"],["1","1","1"]]});