### PR TITLE
Enable cell specific formatting in PowerPoint tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,32 @@ Specific options for tables (in addition to standard : x, y, cx, cy, etc.) :
 - columnWidth : width of all columns (same size for all columns). Must be a number (~1 000 000)
 - columnWidths : list of width for each columns (custom size per column). Must be array of number. This param will overwrite columnWidth if both are given
 
+Formatting can also be applied directly to a cell:
+
+```javascript
+var rows = [];
+rows.push([
+	{
+		val: "Category",
+        	opts: {
+          		font_face   : "Arial",
+          		align       : "l",
+          		bold        : 0
+        	}
+      },
+      {
+        	val  :"Average Score",
+        	opts: {
+          		font_face   : "Arial",
+          		align       : "r",
+          		bold        : 1,
+          		font_color  : "000000",
+          		fill_color  : "f5f5f5"
+        	}
+      }
+]);
+slide.addTable(rows, {});
+```
 
 ## Word: ##
 

--- a/examples/make_pptx.js
+++ b/examples/make_pptx.js
@@ -135,9 +135,10 @@ function generateExampleSlides(callback) {
   callback();
 }
 
-function generateTable(callback) {
+function generateTables(callback) {
   slide = pptx.makeNewSlide();
 
+  //Table with consistent formats
   var rows = [];
   var columnWidths = [];
   for (var i = 0; i < 12; i++) {
@@ -150,6 +151,63 @@ function generateTable(callback) {
   }
 
   slide.addTable(rows, {font_size:9, font_face:"Comic Sans MS", columnWidths:columnWidths});
+
+  //Table with various formats for cells
+  var headerRow = [{ val: 'Region',
+    opts: {
+      bold: 1
+    }},
+    { val: 'Abr.',
+      opts: {
+        bold: 1
+      }},
+    { val: 'Pop.',
+      opts: {
+        bold: 1
+      }},
+    { val: 'Sq. Km.',
+      opts: {
+        bold: 1
+      }}];
+  var dataRows = [
+    {
+      val: 'Midwest',
+      opts: {
+        font_face   : 'Verdana',
+        align       : 'l'
+      }
+    },
+    {
+      val: 'MW',
+      opts: {
+        font_face   : 'Verdana',
+        align       : 'l'
+      }
+    },
+    {
+      val  :2000000,
+      opts: {
+        font_face   : 'Verdana',
+        align       : 'r',
+        bold        : 1,
+        font_color  : 'ffffff',
+        fill_color   : '00a65a'
+      }
+    },
+    {
+      val  :45,
+      opts: {
+        font_face   : 'Verdana',
+        align       : 'r',
+        bold        : 1,
+        fill_color   : 'cccccc'
+      }
+    }
+  ];
+  var columnDefinition = [4286250,952500,952500,952500];
+
+  slide.addTable([headerRow, dataRows], {font_size:10, font_face:"Arial", columnWidths:columnDefinition});
+
   callback();
 }
 
@@ -164,6 +222,6 @@ function finalize() {
 }
 
 async.series([
-  generateTable,
+  generateTables,
   generateExampleSlides // inherited from original project
 ], finalize);

--- a/lib/genofficetable.js
+++ b/lib/genofficetable.js
@@ -6,23 +6,29 @@ module.exports = {
   // assume passed in an array of row objects
   getTable: function(rows, options) {
     var options = options || {};
-	options.tabstyle=options.tabstyle?options.tabstyle:"{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}"
+    options.tabstyle=options.tabstyle?options.tabstyle:"{5C22544A-7EE6-4342-B048-85BDC9FD1C3A}"
     if (options.columnWidth === undefined) {
       options.columnWidth = 8 / (rows[0].length) * EMU
     }
     var self = this;
 
     return self._getBase(
-        rows.map(function(row,row_idx) {
-          return self._getRow(
-              row.map(function(val,idx) {
-                return self._getCell(val, options,idx,row_idx);
-              }),
-              options
-          );
-        }),
-        self._getColSpecs(rows, options),
-        options
+      rows.map(function(row,row_idx) {
+        return self._getRow(
+          row.map(function(val,idx) {
+            var cellVal = val, cellOptions = options;
+            if ((typeof val === 'object')) { //Cell-specific formatting passed in, override table options
+              cellOptions = (val.hasOwnProperty('opts')) ? val.opts : options;
+              cellVal = (val.hasOwnProperty('val')) ? val.val : val;
+            }
+
+            return self._getCell(cellVal, cellOptions,idx,row_idx);
+          }),
+          options
+        );
+      }),
+      self._getColSpecs(rows, options),
+      options
     )
   },
 
@@ -111,21 +117,22 @@ module.exports = {
   _getCell: function (val, options,idx,row_idx) {
     var font_size = options.font_size || 14;
     var font_face = options.font_face || "Times New Roman";
-    return {
+    var cellObject = {
       "a:tc": {
         "a:txBody": {
           "a:bodyPr": {},
           "a:lstStyle": {},
 
-          "a:p": {"a:pPr":{"@algn":options.align?(options.align[idx]?options.align[idx]:'ctr'):'ctr'},
+          "a:p": {
+            "a:pPr": {"@algn": options.align ? (options.align[idx] ? options.align[idx] : options.align) : 'ctr'},
             "a:r": {
               "a:rPr": {
                 "@lang": "en-US",
-                "@sz": ""+font_size*100,
+                "@sz": "" + font_size * 100,
                 "@dirty": "0",
                 "@smtClean": "0",
-				"@b":options.bold?(options.bold[row_idx]?(options.bold[row_idx][idx]?options.bold[row_idx][idx]:"0"):"0"):"0",
-                "@i":options.italics?(options.italics[row_idx]?(options.italics[row_idx][idx]?options.italics[row_idx][idx]:"0"):"0"):"0",
+                "@b": options.bold ? (options.bold[row_idx] ? (options.bold[row_idx][idx] ? options.bold[row_idx][idx] : options.bold[row_idx] ) : options.bold) : "0",
+                "@i": options.italics ? (options.italics[row_idx] ? (options.italics[row_idx][idx] ? options.italics[row_idx][idx] : options.italics[row_idx]) : options.italics) : "0",
                 "a:latin": {
                   "@typeface": font_face
                 },
@@ -137,7 +144,7 @@ module.exports = {
             },
             "a:endParaRPr": {
               "@lang": "en-US",
-              "@sz": ""+font_size*100,
+              "@sz": "" + font_size * 100,
               "@dirty": "0",
               "a:latin": {
                 "@typeface": font_face
@@ -150,6 +157,26 @@ module.exports = {
         },
         "a:tcPr": {}
       }
+    };
+
+    if(options.hasOwnProperty('fill_color')){
+      //Apply background fill to table cell
+      cellObject["a:tc"]["a:tcPr"]["a:solidFill"] = {
+        "a:srgbClr": {
+          "@val": options.fill_color
+        }
+      };
     }
+
+    if(options.hasOwnProperty('font_color')){
+      //Apply color to text run
+      cellObject["a:tc"]["a:txBody"]["a:p"]["a:r"]["a:rPr"]["a:solidFill"] = {
+        "a:srgbClr": {
+          "@val": options.font_color
+        }
+      };
+    }
+
+    return cellObject;
   }
 }


### PR DESCRIPTION
Added ability to set cell attributes of font family, font size, font color (new), bold, italics, alignment, and fill color (new), overriding any table level options or defaults.  Attempted to keep naming/code patterns consistent with those used for docx tables (in docxtable.js).