### PR TITLE
Fix issue with createByJson

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+- Version 0.4.6:
+  - Fixed issue with createByJson - Merge pull request #209 from goyney/master
 - Version 0.4.5:
 	- Added dot bullets.
 	- Option to append text to the content object of a slide based on the "text and content" layout.
@@ -107,7 +109,7 @@
 		- Generating invalid strings for MS-Office document properties.
 		- Better shared string support in Excel (thanks vivocha!).
 - Version 0.2.0:
-	- Huge design change from 'quick patch' based code to real design with much better API while still supporting also 
+	- Huge design change from 'quick patch' based code to real design with much better API while still supporting also
 	  the old API.
 	- Bugs:
 		- You can now listen on error events.
@@ -153,4 +155,3 @@
 	- Can generate very limited Excel file.
 	- You can change the background color of slides.
 	- Minor bug fixes.
-

--- a/lib/gendocx.js
+++ b/lib/gendocx.js
@@ -722,8 +722,8 @@ function makeDocx ( genobj, new_type, options, gen_private, type_info ) {
 		dataArray = [].concat(dataArray || []);
 		dataArray.forEach(function(data) {
 			if(Array.isArray(data)) {
-				newP = genobj.createP(data.shift() || {});
-				data.forEach( function(d) {
+				newP = genobj.createP(data[0] || {});
+				data.forEach(function(d) {
 					newP = genobj.createJson(d, newP);
 				});
 			} else {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "officegen",
 	"description": "Office Open XML Generator using Node.js streams. Supporting Microsoft Office 2007 and later Word (docx), PowerPoint (pptx,ppsx) and Excel (xlsx). This module is for all frameworks and environments. No need for any commandline tool - this module is doing everything inside it.",
-	"version": "0.4.5",
+	"version": "0.4.6",
 	"author": {
 		"name": "Ziv Barber",
 		"url": "https://github.com/Ziv-Barber"


### PR DESCRIPTION
Fix issue with createByJson for docx documents which would strip the very first element from the JSON object which is outlined in https://github.com/Ziv-Barber/officegen/issues/208.

`shift()` removes the first element from the array, so it's used to make the new paragraph but then is never rendered.