### PR TITLE
Fix missing require('path')

### DIFF
--- a/lib/docx-p.js
+++ b/lib/docx-p.js
@@ -29,6 +29,7 @@
 //
 
 var fast_image_size = require('fast-image-size');
+var path = require('path');
 
 /**
  * This function implementing the paragraph API for docx based documents.

--- a/lib/gendocx.js
+++ b/lib/gendocx.js
@@ -38,8 +38,6 @@ var docxP = require('./docx-p.js');
 var docxTable = require('./docxtable.js');
 var xmlBuilder = require('xmlbuilder');
 
-var path = require('path');
-
 var docplugman = require('./docplug');
 
 // Officegen docx plugins:


### PR DESCRIPTION
This bug was introduced by 74e04fafe664f07c4012b77f4002a64e3e276e2a when the paragraph code was moved into it's own file. This accounts for the unused require('path') in gendocx.js

Bug: https://github.com/Ziv-Barber/officegen/issues/191 