### PR TITLE
Round cx and cy values for images

### DIFF
--- a/lib/gendocx.js
+++ b/lib/gendocx.js
@@ -376,7 +376,7 @@ function makeDocx ( genobj, new_type, options, gen_private, type_info ) {
 
 						outString += '<w:drawing>';
 						outString += '<wp:inline distT="0" distB="0" distL="0" distR="0">';
-						outString += '<wp:extent cx="' + (objs_list[i].data[j].options.cx * pixelToEmu) + '" cy="' + (objs_list[i].data[j].options.cy * pixelToEmu) + '"/>';
+						outString += '<wp:extent cx="' + Math.round(objs_list[i].data[j].options.cx * pixelToEmu) + '" cy="' + Math.round(objs_list[i].data[j].options.cy * pixelToEmu) + '"/>';
 						outString += '<wp:effectExtent l="19050" t="0" r="9525" b="0"/>';
 
 						outString += '<wp:docPr id="' + (objs_list[i].data[j].image_id + 1) + '" name="Picture ' + objs_list[i].data[j].image_id + '" descr="Picture ' + objs_list[i].data[j].image_id + '">';


### PR DESCRIPTION
Word does not support decimal values, this solves the issue allowing for better control over the size of an image.