### PR TITLE
Remove missing sourcemap url

### DIFF
--- a/lib/msexcel-builder.js
+++ b/lib/msexcel-builder.js
@@ -857,5 +857,3 @@
     'xl/styles.xml': '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><fonts count="2"><font><sz val="11"/><color theme="1"/><name val="宋体"/><family val="2"/><charset val="134"/><scheme val="minor"/></font><font><sz val="9"/><name val="宋体"/><family val="2"/><charset val="134"/><scheme val="minor"/></font></fonts><fills count="2"><fill><patternFill patternType="none"/></fill><fill><patternFill patternType="gray125"/></fill></fills><borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders><cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"><alignment vertical="center"/></xf></cellStyleXfs><cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"><alignment vertical="center"/></xf></cellXfs><cellStyles count="1"><cellStyle name="常规" xfId="0" builtinId="0"/></cellStyles><dxfs count="0"/><tableStyles count="0" defaultTableStyle="TableStyleMedium9" defaultPivotStyle="PivotStyleLight16"/></styleSheet>'
   }
 }).call(this)
-
-// # sourceMappingURL=msexcel-builder.js.map


### PR DESCRIPTION
I get this warning when building in my TypeScript + Electron project.

```
WARNING in ./node_modules/officegen/lib/msexcel-builder.js
Module Warning (from ./node_modules/source-map-loader/index.js):
(Emitted value instead of an instance of Error) Cannot find SourceMap 'msexcel-builder.js.map': Error: Can't resolve './msexcel-builder.js.map' in '<project_dir>/node_modules/officegen/lib'
```

No other files reference source maps, so I assume it's ok to remove this.