### PR TITLE
Round cx and cy values for images in a:ext tag

### DIFF
--- a/lib/docx/gendocx.js
+++ b/lib/docx/gendocx.js
@@ -550,9 +550,9 @@ function makeDocx(genobj, new_type, options, gen_private, type_info) {
             outString += '<a:off x="0" y="0"/>'
             outString +=
               '<a:ext cx="' +
-              objs_list[i].data[j].options.cx * pixelToEmu +
+              Math.round(objs_list[i].data[j].options.cx * pixelToEmu) +
               '" cy="' +
-              objs_list[i].data[j].options.cy * pixelToEmu +
+              Math.round(objs_list[i].data[j].options.cy * pixelToEmu) +
               '"/>'
             outString += '</a:xfrm>'
             outString += '<a:prstGeom prst="rect">'


### PR DESCRIPTION
This was partially fixed by commit 4032364c081ea2b3cb76c03fca311c480cd369e3, but only in the `wp:extent` tag. The docx I generated still had decimals in the `a:ext` tag, and Word was complaining that the file was corrupt.

With this fix, the docx file was properly generated.