### PR TITLE
docx-p/addText: explicitly convert text to string

### DIFF
--- a/lib/docx/docx-p.js
+++ b/lib/docx/docx-p.js
@@ -108,7 +108,7 @@ MakeDocxP.prototype.setStyle = function (style_name) {
 MakeDocxP.prototype.addText = function (text_msg, opt, flag_data) {
   var newP = this
   var objNum = newP.data.length
-  var textMsg = text_msg.replace(/(?:\r\n|\r)/g, '\n').split('\n')
+  var textMsg = text_msg.toString().replace(/(?:\r\n|\r)/g, '\n').split('\n')
 
   textMsg.forEach(function (value, index) {
     newP.data[objNum] = {


### PR DESCRIPTION
`text_msg` (the first argument of the `addText()`) might always not be a string (i.g. it can be a number). It's better to add explicit conversion `toString()` so code would not throw any errors similar to `text_msg.replace is not a function` in line 111.