### PR TITLE
Fix pptx table font color not being applied

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 - Version 0.6.5:
+  - PPTX: Fix table font color not being applied
   - PPTX: Better fonts support in pptx: new options parameter for addText: pitch_family and charset.
 - Version 0.6.4:
   - Apple Pages compatibility and more options (thanks apsavin!).

--- a/examples/make_pptx.js
+++ b/examples/make_pptx.js
@@ -422,7 +422,7 @@ function generateTables(callback) {
         font_face: 'Verdana',
         align: 'r',
         bold: 1,
-        // font_color: 'ffffff',
+        font_color: 'ffffff',
         fill_color: '00a65a'
       }
     },

--- a/lib/pptx/genofficetable.js
+++ b/lib/pptx/genofficetable.js
@@ -181,6 +181,8 @@ module.exports = {
                       : options.italics[row_idx]
                     : options.italics
                   : '0',
+                'a:solidFill': {
+                },
                 'a:latin': {
                   '@typeface': font_face
                 },


### PR DESCRIPTION
Currently font color is not being applied to pptx tables. This is because the font face is somehow overriding the fontcolor. This can be fixed by always defining the fontcolor before the font face. 

Before:
<img width="720" alt="Screenshot 2023-09-19 at 10 46 28 AM" src="https://github.com/Ziv-Barber/officegen/assets/47996057/2dbfd577-b986-4f41-8514-7891409e30d1">

After:
<img width="708" alt="Screenshot 2023-09-19 at 10 46 38 AM" src="https://github.com/Ziv-Barber/officegen/assets/47996057/a69aac41-0569-4051-885c-e7c8f020cdfc">
