### PR TITLE
add bookmarks on createByJson() 

### DIFF
--- a/lib/docx/gendocx.js
+++ b/lib/docx/gendocx.js
@@ -624,7 +624,7 @@ function makeDocx(genobj, new_type, options, gen_private, type_info) {
               bookmarkId +
               '" w:name="' +
               objs_list[i].data[j].bookmark_start +
-              '"/>'
+              '" w:history="1"/>'
 
             // Bookmark end support:
           } else if (objs_list[i].data[j].bookmark_end) {
@@ -1268,6 +1268,12 @@ function makeDocx(genobj, new_type, options, gen_private, type_info) {
       if (Array.isArray(data)) {
         newP = genobj.createP(data[0] || {})
         data.forEach(function (d) {
+          if(d.bookmark_start){
+            newP.startBookmark(d.bookmark_start)
+          }
+          if(d.bookmark_end){
+            newP.endBookmark()
+          }
           newP = genobj.createJson(d, newP)
         })
       } else {


### PR DESCRIPTION
When creating a word document from json data, the bookmark data is not added to the xml. Therefore, this feature is added to make it easier to use